### PR TITLE
reduce interrupt frequency in ray_shade

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+rayshader v0.6.0
+================
+
+• Improved performance for ray_shade in single core mode (@brodieg).
+
 rayshader v0.5.1 (Release date: 2018-09-11):
 ================
 

--- a/src/rayshade.cpp
+++ b/src/rayshade.cpp
@@ -29,6 +29,8 @@ NumericMatrix rayshade_cpp(double sunangle, NumericVector anglebreaks, NumericMa
   int numberangles = anglebreaks.size();
   bool breakloop;
   double maxheight = max(heightmap);
+  int checkinterruptstart, checkinterrupt;
+  checkinterruptstart = checkinterrupt = 50000;
   RProgress::RProgress pb("Raytracing [:bar] ETA: :eta");
   
   if(progbar) {
@@ -44,7 +46,10 @@ NumericMatrix rayshade_cpp(double sunangle, NumericVector anglebreaks, NumericMa
         for (int angentry = 0; angentry < numberangles; angentry++) {
           breakloop = FALSE;
           for(int k = 1; k < maxdist; k++) {
-            Rcpp::checkUserInterrupt();
+            if(!checkinterrupt--) {
+              Rcpp::checkUserInterrupt();
+              checkinterrupt = checkinterruptstart;
+            }
             xcoord = i + sinsunangle * k;
             ycoord = j + cossunangle * k;
             tanangheight = heightmap(i, j) + tan(anglebreaks[angentry]) * k * zscale;


### PR DESCRIPTION
I'm working on a response to [Wolf Vollprecht's Next Journal article](https://nextjournal.com/wolfv/how-fast-is-r-with-fastr-pythran), and I noticed when running benchmarks that `ray_trace` runs substantially slower than the Julia version.  I didn't think this should be the case, so I dug into it and noticed that `Rcpp::checkUserInterrupt()` is called in the innermost for loop.  This is a somewhat expensive operation and can be just as effective if we check every few thousand loops.  

Making the change increases performance by 5x (see below).  Presumably we could make a similar change to the multi core version, and to other places were interrupts are used, but I haven't checked that.  I figure you might have opinions about how to do this, so I didn't want to spend too much time changing things before getting a sense for what you want.

I did also make a change to NEWS, but only because I've been asked to that in pull requests into other projects.  Feel free to edit as you see fit (obviously).

Before changes:
```
library(rayshader)
elev <- seq(-90, 90, length=25)
microbenchmark::microbenchmark(times=10,
  ray_shade(volcano, elev, 45, lambert=FALSE, progbar=FALSE)
)
## Unit: milliseconds
##                                                            expr      min
##  ray_shade(volcano, elev, 45, lambert = FALSE, progbar = FALSE) 134.2335
##        lq     mean   median       uq      max neval
##  135.0545 162.9438 143.9956 177.8761 242.3845    10
```
After changes:
```
library(rayshader)
elev <- seq(-90, 90, length=25)
microbenchmark::microbenchmark(times=10,
  ray_shade(volcano, elev, 45, lambert=FALSE, progbar=FALSE)
)
## Unit: milliseconds
##                                                            expr     min
##  ray_shade(volcano, elev, 45, lambert = FALSE, progbar = FALSE) 25.9512
##        lq     mean   median       uq      max neval
##  26.52456 28.63295 27.44805 27.87292 41.60245    10
```