### PR TITLE
Enable roxygen markdown support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,6 @@ Suggests: reshape2,
           magick
 LinkingTo: Rcpp, progress, RcppArmadillo
 RoxygenNote: 7.0.2
+Roxygen: list(markdown = TRUE)
 URL: https://github.com/tylermorganwall/rayshader
 BugReports: https://github.com/tylermorganwall/rayshader/issues

--- a/R/ambient_shade.R
+++ b/R/ambient_shade.R
@@ -6,7 +6,7 @@
 #'@param anglebreaks Default `90*cospi(seq(5, 85,by =5)/180)`. The angle(s), in degrees, as measured from the horizon from which the light originates.
 #'@param sunbreaks Default `24`. Number of rays to be sent out in a circle, evenly spaced, around the point being tested.
 #'@param maxsearch Default `30`. The maximum horizontal distance that the system should propogate rays to check for surface intersections. 
-#'@param multicore Default FALSE. If TRUE, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
+#'@param multicore Default `FALSE`. If `TRUE`, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
 #'set `options("cores")` in which the multicore option will only use that many cores.
 #'@param zscale Default 1. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. 
 #'@param cache_mask Default `NULL`. A matrix of 1 and 0s, indicating which points on which the raytracer will operate.

--- a/R/data.R
+++ b/R/data.R
@@ -6,5 +6,5 @@
 #'
 #' @format A matrix with 401 rows and 401 columns. Elevation is in meters, and the spacing between each
 #' coordinate is 200 meters (zscale = 200). Water level is 0.
-#' @source \url{https://maps.ngdc.noaa.gov/viewers/bathymetry/?layers=dem}
+#' @source <https://maps.ngdc.noaa.gov/viewers/bathymetry/?layers=dem>
 "montereybay"

--- a/R/plot_3d.R
+++ b/R/plot_3d.R
@@ -31,7 +31,7 @@
 #'@param calculate_normals Default `TRUE`. If `FALSE`, will not calculate per-vertex normals. Can also pass the
 #'output of the function `calculate_normals` to use pre-computed normals.
 #'@param litbase Default `FALSE`. If `TRUE`, the base will be a glossy material lit using the 
-#'`lit = TRUE` parameter in `rgl`. If calling `render_highquality()`, set this to `TRUE` to make sure
+#'`lit = TRUE` parameter in `rgl`. If calling [render_highquality()], set this to `TRUE` to make sure
 #'rgl exports the sizes of the model.
 #'@param windowsize Default `600`. Position, width, and height of the `rgl` device displaying the plot. 
 #'If a single number, viewport will be a square and located in upper left corner. 
@@ -40,7 +40,7 @@
 #'specify the location of the x-y coordinates of the bottom-left corner of the viewport on the screen,
 #'and the next two (or one, if square) specify the window size. NOTE: The absolute positioning of the
 #'window does not currently work on macOS (tested on Mojave), but the size can still be specified.
-#'@param ... Additional arguments to pass to the `rgl::par3d` function.
+#'@param ... Additional arguments to pass to the [rgl::par3d()] function.
 #'@import rgl
 #'@export
 #'@examples

--- a/R/plot_gg.R
+++ b/R/plot_gg.R
@@ -47,7 +47,7 @@
 #'@param save_height_matrix Default `FALSE`. If `TRUE`, the function will return the height matrix used for the ggplot.
 #'@param save_shadow_matrix Default `FALSE`. If `TRUE`, the function will return the shadow matrix for use in future updates via the `shadow_cache` argument passed to `ray_shade`.
 #'@param saved_shadow_matrix Default `NULL`. A cached shadow matrix (saved by the a previous invocation of `plot_gg(..., save_shadow_matrix=TRUE)` to use instead of raytracing a shadow map each time.
-#'@param ... Additional arguments to be passed to `plot_3d()`.
+#'@param ... Additional arguments to be passed to [plot_3d()].
 #'@return Opens a 3D plot in rgl.
 #'@import ggplot2
 #'@export

--- a/R/plot_map.R
+++ b/R/plot_map.R
@@ -6,7 +6,7 @@
 #'@param rotate Default `0`. Rotates the output. Possible values: `0`, `90`, `180`, `270`.
 #'@param keep_user_par Default `TRUE`. Whether to keep the user's `par()` settings. Set to `FALSE` if you 
 #'want to set up a multi-pane plot (e.g. set `par(mfrow)`).
-#'@param ... Additional arguments to pass to the `raster::plotRGB` function that displays the map.
+#'@param ... Additional arguments to pass to the [raster::plotRGB()] function that displays the map.
 #'@export
 #'@examples
 #'#Plotting a spherical texture map of the volcano dataset.

--- a/R/raster_to_matrix.R
+++ b/R/raster_to_matrix.R
@@ -3,7 +3,7 @@
 #'@description Turns a raster into a matrix suitable for rayshader. 
 #'
 #'@param raster The input raster. Either a RasterLayer object, or a filename.
-#'@param verbose Default `interactive()`. Will print dimensions of the resulting matrix.
+#'@param verbose Default [interactive()]. Will print dimensions of the resulting matrix.
 #'@export
 #'@examples
 #'#Save montereybay as a raster and open using the filename.

--- a/R/ray_shade.R
+++ b/R/ray_shade.R
@@ -24,7 +24,7 @@
 #'@param anglebreaks Default `NULL`. A vector of angle(s) in degrees (as measured from the horizon) specifying from where the light originates. 
 #'Use this instead of `sunaltitude` to create a softer shadow by specifying a wider light. E.g. `anglebreaks = seq(40,50,by=0.5)` creates a light 
 #'10 degrees wide, as opposed to the default
-#'@param ... Additional arguments to pass to the `makeCluster` function when `multicore=TRUE`.
+#'@param ... Additional arguments to pass to the [makeCluster()] function when `multicore=TRUE`.
 #'@import foreach doParallel parallel progress
 #'@return Matrix of light intensities at each point.
 #'@export

--- a/R/render_depth.R
+++ b/R/render_depth.R
@@ -4,7 +4,7 @@
 #'
 #'The size of the circle of confusion is determined by the following formula (z_depth is from the image's depth map).
 #'
-#'\code{abs(z_depth-focus)*focal_length^2/(f_stop*z_depth*(focus - focal_length))}
+#'`abs(z_depth-focus)*focal_length^2/(f_stop*z_depth*(focus - focal_length))``
 #'
 #'@param focus Defaults `0.5`. Depth in which to blur. Minimum 0, maximum 1.
 #'@param focallength Default `1`. Focal length of the virtual camera.
@@ -20,9 +20,9 @@
 #'@param gamma_correction Default `TRUE`. Controls gamma correction when adding colors. Default exponent of 2.2.
 #'@param transparent_water Default `FALSE`. If `TRUE`, depth is determined without water layer. User will have to re-render the water
 #'layer with `render_water()` if they want to recreate the water layer.
-#'@param heightmap Default `NULL`. The height matrix for the scene. Passing this will allow `render_depth()` 
+#'@param heightmap Default `NULL`. The height matrix for the scene. Passing this will allow [render_depth()] 
 #'to automatically redraw the water layer if `transparent_water = TRUE`.
-#'@param zscale Default `NULL`. The zscale value for the heightmap. Passing this will allow `render_depth()` 
+#'@param zscale Default `NULL`. The zscale value for the heightmap. Passing this will allow [render_depth()] 
 #'to automatically redraw the water layer if `transparent_water = TRUE`.
 #'@param title_text Default `NULL`. Text. Adds a title to the image, using magick::image_annotate. 
 #'@param title_offset Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
@@ -44,7 +44,7 @@
 #'before taking the snapshot. This can help stop prevent rendering issues when running scripts.
 #'@param clear Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.
 #'@param bring_to_front Default `FALSE`. Whether to bring the window to the front when rendering the snapshot.
-#'@param ... Additional parameters to pass to magick::image_annotate. 
+#'@param ... Additional parameters to pass to [magick::image_annotate()]. 
 #'@return 4-layer RGBA array.
 #'@export
 #'@examples

--- a/R/render_depth.R
+++ b/R/render_depth.R
@@ -4,7 +4,7 @@
 #'
 #'The size of the circle of confusion is determined by the following formula (z_depth is from the image's depth map).
 #'
-#'`abs(z_depth-focus)*focal_length^2/(f_stop*z_depth*(focus - focal_length))``
+#'`abs(z_depth-focus)*focal_length^2/(f_stop*z_depth*(focus - focal_length))`
 #'
 #'@param focus Defaults `0.5`. Depth in which to blur. Minimum 0, maximum 1.
 #'@param focallength Default `1`. Focal length of the virtual camera.

--- a/R/render_highquality.R
+++ b/R/render_highquality.R
@@ -15,20 +15,20 @@
 #'@param lightsize Default `NULL`. Radius of the light(s). Automatically chosen, but can be set here by the user.
 #'@param lightintensity Default `500`. Intensity of the light.
 #'@param lightcolor Default `white`. The color of the light.
-#'@param obj_material Default `rayrender::diffuse()`. The material properties of the object file. 
+#'@param obj_material Default [rayrender::diffuse()]. The material properties of the object file. 
 #'@param cache_filename Name of temporary filename to store OBJ file, if the user does not want to rewrite the file each time.
 #'@param width Defaults to the width of the rgl window. Width of the rendering. 
 #'@param height Defaults to the height of the rgl window. Height of the rendering. 
 #'@param title_text Default `NULL`. Text. Adds a title to the image, using magick::image_annotate. 
 #'@param title_offset Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-#'image_annotate) corner to offset the title.
+#'[magick::image_annotate()] corner to offset the title.
 #'@param title_size Default `30`. Font size in pixels.
 #'@param title_color Default `black`. Font color.
 #'@param title_font Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
 #'"Trebuchet", "Georgia", "Palatino" or "Comic Sans".
 #'@param title_bar_color Default `NULL`. If a color, this will create a colored bar under the title.
 #'@param title_bar_alpha Default `0.5`. Transparency of the title bar.
-#'@param ground_material Default `diffuse()`. Material defined by the rayrender material functions.
+#'@param ground_material Default [diffuse()][rayrender::diffuse()]. Material defined by the rayrender material functions.
 #'@param ground_size Default `100000`. The width of the plane representing the ground.
 #'@param camera_location Default `NULL`. Custom position of the camera. The `FOV`, `width`, and `height` arguments will still
 #'be derived from the rgl window.
@@ -39,7 +39,7 @@
 #'@param scene_elements Default `NULL`. Extra scene elements to add to the scene, created with rayrender.
 #'@param clear Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.
 #'@param print_scene_info Default `FALSE`. If `TRUE`, it will print the position and lookat point of the camera.
-#'@param ... Additional parameters to pass to rayrender::render_scene()
+#'@param ... Additional parameters to pass to [rayrender::render_scene()]
 #'@import rayrender
 #'@export
 #'@examples

--- a/R/render_label.R
+++ b/R/render_label.R
@@ -10,7 +10,7 @@
 #'@param zscale Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
 #'@param relativez Default `TRUE`. Whether `z` should be measured in relation to the underlying elevation at that point in the heightmap, or set absolutely (`FALSE`).
 #'@param offset Elevation above the surface (at the label point) to start drawing the line.
-#'@param clear_previous Default `FALSE`. If `TRUE`, it will clear all existing text and lines rendered with `render_label()`. If no
+#'@param clear_previous Default `FALSE`. If `TRUE`, it will clear all existing text and lines rendered with [render_label()]. If no
 #'other arguments are passed to `render_label()`, this will just remove all existing lines.
 #'@param textsize Default `1`. A numeric character expansion value.
 #'@param dashed Default `FALSE`. If `TRUE`, the label line is dashed.

--- a/R/render_movie.R
+++ b/R/render_movie.R
@@ -16,7 +16,7 @@
 #'@param fov Defaults to the current view. Field of view values, in degrees.
 #'@param title_text Default `NULL`. Text. Adds a title to the movie, using magick::image_annotate. 
 #'@param title_offset Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-#'image_annotate) corner to offset the title.
+#'[magick::image_annotate()]) corner to offset the title.
 #'@param title_size Default `30`. Font size in pixels.
 #'@param title_color Default `black`. Font color.
 #'@param title_font Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
@@ -32,7 +32,7 @@
 #'@param audio Default `NULL`. Optional file with audio to add to the video.
 #'@param progbar Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, turns off progress bar. 
 #'Will display a progress bar when adding an overlay or title.
-#'@param ... Additional parameters to pass to magick::image_annotate. 
+#'@param ... Additional parameters to pass to [magick::image_annotate()]. 
 #'@export
 #'@examples
 #'filename_movie = tempfile()

--- a/R/render_snapshot.R
+++ b/R/render_snapshot.R
@@ -5,7 +5,7 @@
 #'@param filename Filename of snapshot. If missing, will display to current device.
 #'@param title_text Default `NULL`. Text. Adds a title to the image, using magick::image_annotate. 
 #'@param title_offset Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-#'image_annotate) corner to offset the title.
+#'[magick::image_annotate()]) corner to offset the title.
 #'@param title_size Default `30`. Font size in pixels.
 #'@param title_color Default `black`. Font color.
 #'@param title_font Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
@@ -22,7 +22,7 @@
 #'@param instant_capture Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, a slight delay is added 
 #'before taking the snapshot. This can help stop prevent rendering issues when running scripts.
 #'@param bring_to_front Default `FALSE`. Whether to bring the window to the front when taking the snapshot.
-#'@param ... Additional parameters to pass to magick::image_annotate. 
+#'@param ... Additional parameters to pass to [magick::image_annotate()]. 
 #'@return Displays snapshot of current rgl plot (or saves to disk).
 #'@export
 #'@examples

--- a/man/add_overlay.Rd
+++ b/man/add_overlay.Rd
@@ -16,20 +16,20 @@ add_overlay(
 \arguments{
 \item{hillshade}{A three-dimensional RGB array or 2D matrix of shadow intensities.}
 
-\item{overlay}{A three or four dimensional RGB array, where the 4th dimension represents the alpha (transparency) channel. 
-If the array is 3D, `alphacolor` should also be passed to indicate transparent regions.}
+\item{overlay}{A three or four dimensional RGB array, where the 4th dimension represents the alpha (transparency) channel.
+If the array is 3D, \code{alphacolor} should also be passed to indicate transparent regions.}
 
-\item{alphacolor}{Default `NULL`. If `overlay` is a 3-layer array, this argument tells which color is interpretted as completely transparent.}
+\item{alphacolor}{Default \code{NULL}. If \code{overlay} is a 3-layer array, this argument tells which color is interpretted as completely transparent.}
 
-\item{alphalayer}{Default `1`. Defines minimum tranparaency of layer. If transparency already exists in `overlay`, the way `add_overlay` combines 
-the two is determined in argument `alphamethod`.}
+\item{alphalayer}{Default \code{1}. Defines minimum tranparaency of layer. If transparency already exists in \code{overlay}, the way \code{add_overlay} combines
+the two is determined in argument \code{alphamethod}.}
 
-\item{alphamethod}{Default `max`. Method for dealing with pre-existing transparency with `layeralpha`. 
-If `max`, converts all alpha levels higher than `layeralpha` to the value set in `layeralpha`.
-If `multiply`, multiples all pre-existing alpha values with `layeralpha`.
-If `none`, keeps existing tranparencies and only changes opaque entries.}
+\item{alphamethod}{Default \code{max}. Method for dealing with pre-existing transparency with \code{layeralpha}.
+If \code{max}, converts all alpha levels higher than \code{layeralpha} to the value set in \code{layeralpha}.
+If \code{multiply}, multiples all pre-existing alpha values with \code{layeralpha}.
+If \code{none}, keeps existing tranparencies and only changes opaque entries.}
 
-\item{gamma_correction}{Default `TRUE`. Controls gamma correction when adding colors. Default exponent of 2.2.}
+\item{gamma_correction}{Default \code{TRUE}. Controls gamma correction when adding colors. Default exponent of 2.2.}
 }
 \value{
 Hillshade with overlay.

--- a/man/add_water.Rd
+++ b/man/add_water.Rd
@@ -11,9 +11,9 @@ add_water(hillshade, watermap, color = "imhof1")
 
 \item{watermap}{Matrix indicating whether water was detected at that point. 1 indicates water, 0 indicates no water.}
 
-\item{color}{Default `imhof1`. The water fill color. A hexcode or recognized color string. 
-Also includes built-in colors to match the palettes included in sphere_shade: 
-(`imhof1`,`imhof2`,`imhof3`,`imhof4`, `desert`, `bw`, and `unicorn`).}
+\item{color}{Default \code{imhof1}. The water fill color. A hexcode or recognized color string.
+Also includes built-in colors to match the palettes included in sphere_shade:
+(\code{imhof1},\code{imhof2},\code{imhof3},\code{imhof4}, \code{desert}, \code{bw}, and \code{unicorn}).}
 }
 \description{
 Adds a layer of water to a map.

--- a/man/ambient_shade.Rd
+++ b/man/ambient_shade.Rd
@@ -20,24 +20,24 @@ ambient_shade(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{anglebreaks}{Default `90*cospi(seq(5, 85,by =5)/180)`. The angle(s), in degrees, as measured from the horizon from which the light originates.}
+\item{anglebreaks}{Default \code{90*cospi(seq(5, 85,by =5)/180)}. The angle(s), in degrees, as measured from the horizon from which the light originates.}
 
-\item{sunbreaks}{Default `24`. Number of rays to be sent out in a circle, evenly spaced, around the point being tested.}
+\item{sunbreaks}{Default \code{24}. Number of rays to be sent out in a circle, evenly spaced, around the point being tested.}
 
-\item{maxsearch}{Default `30`. The maximum horizontal distance that the system should propogate rays to check for surface intersections.}
+\item{maxsearch}{Default \code{30}. The maximum horizontal distance that the system should propogate rays to check for surface intersections.}
 
-\item{multicore}{Default FALSE. If TRUE, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
-set `options("cores")` in which the multicore option will only use that many cores.}
+\item{multicore}{Default \code{FALSE}. If \code{TRUE}, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
+set \code{options("cores")} in which the multicore option will only use that many cores.}
 
 \item{zscale}{Default 1. The ratio between the x and y spacing (which are assumed to be equal) and the z axis.}
 
-\item{cache_mask}{Default `NULL`. A matrix of 1 and 0s, indicating which points on which the raytracer will operate.}
+\item{cache_mask}{Default \code{NULL}. A matrix of 1 and 0s, indicating which points on which the raytracer will operate.}
 
-\item{shadow_cache}{Default `NULL`. The shadow matrix to be updated at the points defined by the argument `cache_mask`.}
+\item{shadow_cache}{Default \code{NULL}. The shadow matrix to be updated at the points defined by the argument \code{cache_mask}.}
 
-\item{progbar}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, turns off progress bar.}
+\item{progbar}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, turns off progress bar.}
 
-\item{...}{Additional arguments to pass to the `makeCluster` function when `multicore=TRUE`.}
+\item{...}{Additional arguments to pass to the \code{makeCluster} function when \code{multicore=TRUE}.}
 }
 \value{
 Shaded texture map.

--- a/man/calculate_normal.Rd
+++ b/man/calculate_normal.Rd
@@ -11,7 +11,7 @@ calculate_normal(heightmap, zscale = 1, progbar = FALSE)
 
 \item{zscale}{Default 1.}
 
-\item{progbar}{Default `FALSE`. If `TRUE`, turns on progress bar.}
+\item{progbar}{Default \code{FALSE}. If \code{TRUE}, turns on progress bar.}
 }
 \value{
 Matrix of light intensities at each point.

--- a/man/create_texture.Rd
+++ b/man/create_texture.Rd
@@ -16,18 +16,18 @@ create_texture(
 \arguments{
 \item{lightcolor}{The main highlight color. Corresponds to the top center of the texture map.}
 
-\item{shadowcolor}{The main shadow color. Corresponds to the bottom center of the texture map. This color represents slopes directed 
+\item{shadowcolor}{The main shadow color. Corresponds to the bottom center of the texture map. This color represents slopes directed
 directly opposite to the main highlight color.}
 
-\item{leftcolor}{The left fill color. Corresponds to the left center of the texture map. This color represents slopes directed 
+\item{leftcolor}{The left fill color. Corresponds to the left center of the texture map. This color represents slopes directed
 90 degrees to the left of the main highlight color.}
 
-\item{rightcolor}{The right fill color. Corresponds to the right center of the texture map. This color represents slopes directed 
+\item{rightcolor}{The right fill color. Corresponds to the right center of the texture map. This color represents slopes directed
 90 degrees to the right of the main highlight color.}
 
 \item{centercolor}{The center color. Corresponds to the center of the texture map. This color represents flat areas.}
 
-\item{cornercolors}{Default `NULL`. The colors at the corners, in this order: NW, NE, SW, SE. If this vector isn't present (or
+\item{cornercolors}{Default \code{NULL}. The colors at the corners, in this order: NW, NE, SW, SE. If this vector isn't present (or
 all corners are specified), the mid-points will just be interpolated from the main colors.}
 }
 \description{

--- a/man/detect_water.Rd
+++ b/man/detect_water.Rd
@@ -18,20 +18,20 @@ detect_water(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All grid points are assumed to be evenly spaced.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{cutoff}{Default `0.999`. The lower limit of the z-component of the unit normal vector to be classified as water.}
+\item{cutoff}{Default \code{0.999}. The lower limit of the z-component of the unit normal vector to be classified as water.}
 
 \item{min_area}{Default length(heightmap)/400. Minimum area (in units of the height matrix x and y spacing) to be considered a body of water.}
 
-\item{max_height}{Default `NULL`. If passed, this number will specify the maximum height a point can be considered to be water.}
+\item{max_height}{Default \code{NULL}. If passed, this number will specify the maximum height a point can be considered to be water.}
 
-\item{normalvectors}{Default `NULL`. Pre-computed array of normal vectors from the `calculate_normal` function. Supplying this will speed up water detection.}
+\item{normalvectors}{Default \code{NULL}. Pre-computed array of normal vectors from the \code{calculate_normal} function. Supplying this will speed up water detection.}
 
-\item{keep_groups}{Default `FALSE`. If `TRUE`, the matrix returned will retain the numbered grouping information.}
+\item{keep_groups}{Default \code{FALSE}. If \code{TRUE}, the matrix returned will retain the numbered grouping information.}
 
-\item{progbar}{Default `FALSE`. If `TRUE`, turns on progress bar.}
+\item{progbar}{Default \code{FALSE}. If \code{TRUE}, turns on progress bar.}
 }
 \value{
 Matrix indicating whether water was detected at that point. 1 indicates water, 0 indicates no water.

--- a/man/get_ids_with_labels.Rd
+++ b/man/get_ids_with_labels.Rd
@@ -7,7 +7,7 @@
 get_ids_with_labels(typeval = NULL)
 }
 \arguments{
-\item{typeval}{Default `NULL`. Select to filter just one of the types: `surface`, `base`,`lines`, `waterlines`,`shadow`, `basebottom`,}
+\item{typeval}{Default \code{NULL}. Select to filter just one of the types: \code{surface}, \code{base},\code{lines}, \code{waterlines},\code{shadow}, \code{basebottom},}
 }
 \value{
 Data frame of IDs with labels

--- a/man/height_shade.Rd
+++ b/man/height_shade.Rd
@@ -9,7 +9,7 @@ height_shade(heightmap, texture = grDevices::terrain.colors(256))
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point.}
 
-\item{texture}{Default `terrain.colors(256)`. A color palette for the plot.}
+\item{texture}{Default \code{terrain.colors(256)}. A color palette for the plot.}
 }
 \value{
 RGB array of hillshaded texture mappings.

--- a/man/lamb_shade.Rd
+++ b/man/lamb_shade.Rd
@@ -15,19 +15,19 @@ lamb_shade(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{sunaltitude}{Default `45`. The azimuth angle as measured from the horizon from which the light originates.}
+\item{sunaltitude}{Default \code{45}. The azimuth angle as measured from the horizon from which the light originates.}
 
-\item{sunangle}{Default `315` (NW). The angle around the matrix from which the light originates.}
+\item{sunangle}{Default \code{315} (NW). The angle around the matrix from which the light originates.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis.}
 
-\item{zero_negative}{Default `TRUE`. Zeros out all values below 0 (corresponding to surfaces facing away from the light source).}
+\item{zero_negative}{Default \code{TRUE}. Zeros out all values below 0 (corresponding to surfaces facing away from the light source).}
 }
 \value{
 Matrix of light intensities at each point.
 }
 \description{
-Calculates local shadow map for a elevation matrix by calculating the dot 
+Calculates local shadow map for a elevation matrix by calculating the dot
 product between light direction and the surface normal vector at that point. Each point's
 intensity is proportional to the cosine of the normal vector.
 }

--- a/man/make_base.Rd
+++ b/man/make_base.Rd
@@ -15,14 +15,14 @@ make_base(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{basedepth}{Default `0`.}
+\item{basedepth}{Default \code{0}.}
 
-\item{basecolor}{Default `grey20`.}
+\item{basecolor}{Default \code{grey20}.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{litbase}{Default `FALSE`.}
+\item{litbase}{Default \code{FALSE}.}
 }
 \description{
 Makes the base below the 3D elevation map.

--- a/man/make_lines.Rd
+++ b/man/make_lines.Rd
@@ -17,18 +17,18 @@ make_lines(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{basedepth}{Default `0`.}
+\item{basedepth}{Default \code{0}.}
 
-\item{linecolor}{Default `grey40`.}
+\item{linecolor}{Default \code{grey40}.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{alpha}{Default `1`. Transparency.}
+\item{alpha}{Default \code{1}. Transparency.}
 
-\item{linewidth}{Default `2`. Linewidth}
+\item{linewidth}{Default \code{2}. Linewidth}
 
-\item{solid}{Default `TRUE`. Whether it's solid or water.}
+\item{solid}{Default \code{TRUE}. Whether it's solid or water.}
 }
 \description{
 Makes the lines in the corner of the base.

--- a/man/make_shadow.Rd
+++ b/man/make_shadow.Rd
@@ -9,9 +9,9 @@ make_shadow(heightmap, basedepth, shadowwidth, color, shadowcolor)
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{basedepth}{Default `grey20`.}
+\item{basedepth}{Default \code{grey20}.}
 
-\item{shadowwidth}{Default `50`. Shadow width.}
+\item{shadowwidth}{Default \code{50}. Shadow width.}
 }
 \description{
 Makes the base below the 3D elevation map.

--- a/man/make_vignette_overlay.Rd
+++ b/man/make_vignette_overlay.Rd
@@ -11,9 +11,9 @@ make_vignette_overlay(width, height, intensity = 0.3, radius = NULL)
 
 \item{height}{Height of the image.}
 
-\item{intensity}{Default `0.4`. `1` is max intensity, `0` is min.}
+\item{intensity}{Default \code{0.4}. \code{1} is max intensity, \code{0} is min.}
 
-\item{radius}{Default `NULL`. Max of height or width, divided by 2.}
+\item{radius}{Default \code{NULL}. Max of height or width, divided by 2.}
 }
 \description{
 Makes an overlay to simulate vignetting in a camera

--- a/man/make_water.Rd
+++ b/man/make_water.Rd
@@ -15,14 +15,14 @@ make_water(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{waterheight}{Default `0`.}
+\item{waterheight}{Default \code{0}.}
 
-\item{watercolor}{Default `blue`.}
+\item{watercolor}{Default \code{blue}.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{wateralpha}{Default `0.5`. Water transparency.}
+\item{wateralpha}{Default \code{0.5}. Water transparency.}
 }
 \description{
 Makes the water in the 3D elevation map.

--- a/man/make_waterlines.Rd
+++ b/man/make_waterlines.Rd
@@ -17,18 +17,18 @@ make_waterlines(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{waterdepth}{Default `0`.}
+\item{waterdepth}{Default \code{0}.}
 
-\item{linecolor}{Default `grey40`.}
+\item{linecolor}{Default \code{grey40}.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{alpha}{Default `1`. Transparency of lines.}
+\item{alpha}{Default \code{1}. Transparency of lines.}
 
-\item{linewidth}{Default `2`. Water line width.}
+\item{linewidth}{Default \code{2}. Water line width.}
 
-\item{antialias}{Default `FALSE`.}
+\item{antialias}{Default \code{FALSE}.}
 }
 \description{
 Makes the edge lines of

--- a/man/montereybay.Rd
+++ b/man/montereybay.Rd
@@ -13,8 +13,8 @@ coordinate is 200 meters (zscale = 200). Water level is 0.}
 montereybay
 }
 \description{
-This dataset is a downsampled version of a combined topographic and bathymetric 
-elevation matrix representing the Monterey Bay, CA region. Original data from 
+This dataset is a downsampled version of a combined topographic and bathymetric
+elevation matrix representing the Monterey Bay, CA region. Original data from
 from the NOAA National Map website.
 }
 \keyword{datasets}

--- a/man/plot_3d.Rd
+++ b/man/plot_3d.Rd
@@ -41,72 +41,72 @@ plot_3d(
 
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10. Adjust the zscale down to exaggerate elevation features.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10. Adjust the zscale down to exaggerate elevation features.}
 
-\item{baseshape}{Default `rectangle`. Shape of the base. Options are c("rectangle","circle","hex").}
+\item{baseshape}{Default \code{rectangle}. Shape of the base. Options are c("rectangle","circle","hex").}
 
-\item{solid}{Default `TRUE`. If `FALSE`, just the surface is rendered.}
+\item{solid}{Default \code{TRUE}. If \code{FALSE}, just the surface is rendered.}
 
-\item{soliddepth}{Default `auto`, which sets it to the lowest elevation in the matrix minus one unit (scaled by zscale). Depth of the solid base.}
+\item{soliddepth}{Default \code{auto}, which sets it to the lowest elevation in the matrix minus one unit (scaled by zscale). Depth of the solid base.}
 
-\item{solidcolor}{Default `grey20`. Base color.}
+\item{solidcolor}{Default \code{grey20}. Base color.}
 
-\item{solidlinecolor}{Default `grey30`. Base edge line color.}
+\item{solidlinecolor}{Default \code{grey30}. Base edge line color.}
 
-\item{shadow}{Default `TRUE`. If `FALSE`, no shadow is rendered.}
+\item{shadow}{Default \code{TRUE}. If \code{FALSE}, no shadow is rendered.}
 
-\item{shadowdepth}{Default `auto`, which sets it to `soliddepth - soliddepth/10`. Depth of the shadow layer.}
+\item{shadowdepth}{Default \code{auto}, which sets it to \code{soliddepth - soliddepth/10}. Depth of the shadow layer.}
 
-\item{shadowcolor}{Default `grey50`. Color of the shadow.}
+\item{shadowcolor}{Default \code{grey50}. Color of the shadow.}
 
-\item{shadowwidth}{Default `auto`, which sizes it to 1/10th the smallest dimension of `heightmap`. Width of the shadow in units of the matrix.}
+\item{shadowwidth}{Default \code{auto}, which sizes it to 1/10th the smallest dimension of \code{heightmap}. Width of the shadow in units of the matrix.}
 
-\item{water}{Default `FALSE`. If `TRUE`, a water layer is rendered.}
+\item{water}{Default \code{FALSE}. If \code{TRUE}, a water layer is rendered.}
 
-\item{waterdepth}{Default `0`. Water level.}
+\item{waterdepth}{Default \code{0}. Water level.}
 
-\item{watercolor}{Default `lightblue`. Color of the water.}
+\item{watercolor}{Default \code{lightblue}. Color of the water.}
 
-\item{wateralpha}{Default `0.5`. Water transparency.}
+\item{wateralpha}{Default \code{0.5}. Water transparency.}
 
-\item{waterlinecolor}{Default `NULL`. Color of the lines around the edges of the water layer.}
+\item{waterlinecolor}{Default \code{NULL}. Color of the lines around the edges of the water layer.}
 
-\item{waterlinealpha}{Default `1`. Water line tranparency.}
+\item{waterlinealpha}{Default \code{1}. Water line tranparency.}
 
-\item{linewidth}{Default `2`. Width of the edge lines in the scene.}
+\item{linewidth}{Default \code{2}. Width of the edge lines in the scene.}
 
-\item{lineantialias}{Default `FALSE`. Whether to anti-alias the lines in the scene.}
+\item{lineantialias}{Default \code{FALSE}. Whether to anti-alias the lines in the scene.}
 
-\item{theta}{Default `45`. Rotation around z-axis.}
+\item{theta}{Default \code{45}. Rotation around z-axis.}
 
-\item{phi}{Default `45`. Azimuth angle.}
+\item{phi}{Default \code{45}. Azimuth angle.}
 
-\item{fov}{Default `0`--isometric. Field-of-view angle.}
+\item{fov}{Default \code{0}--isometric. Field-of-view angle.}
 
-\item{zoom}{Default `1`. Zoom factor.}
+\item{zoom}{Default \code{1}. Zoom factor.}
 
-\item{background}{Default `grey10`. Color of the background.}
+\item{background}{Default \code{grey10}. Color of the background.}
 
-\item{calculate_normals}{Default `TRUE`. If `FALSE`, will not calculate per-vertex normals. Can also pass the
-output of the function `calculate_normals` to use pre-computed normals.}
+\item{calculate_normals}{Default \code{TRUE}. If \code{FALSE}, will not calculate per-vertex normals. Can also pass the
+output of the function \code{calculate_normals} to use pre-computed normals.}
 
-\item{litbase}{Default `FALSE`. If `TRUE`, the base will be a glossy material lit using the 
-`lit = TRUE` parameter in `rgl`. If calling `render_highquality()`, set this to `TRUE` to make sure
+\item{litbase}{Default \code{FALSE}. If \code{TRUE}, the base will be a glossy material lit using the
+\code{lit = TRUE} parameter in \code{rgl}. If calling \code{\link[=render_highquality]{render_highquality()}}, set this to \code{TRUE} to make sure
 rgl exports the sizes of the model.}
 
-\item{windowsize}{Default `600`. Position, width, and height of the `rgl` device displaying the plot. 
-If a single number, viewport will be a square and located in upper left corner. 
-If two numbers, (e.g. `c(600,800)`), user will specify width and height separately. 
-If four numbers (e.g. `c(200,0,600,800)`), the first two coordinates 
+\item{windowsize}{Default \code{600}. Position, width, and height of the \code{rgl} device displaying the plot.
+If a single number, viewport will be a square and located in upper left corner.
+If two numbers, (e.g. \code{c(600,800)}), user will specify width and height separately.
+If four numbers (e.g. \code{c(200,0,600,800)}), the first two coordinates
 specify the location of the x-y coordinates of the bottom-left corner of the viewport on the screen,
 and the next two (or one, if square) specify the window size. NOTE: The absolute positioning of the
 window does not currently work on macOS (tested on Mojave), but the size can still be specified.}
 
-\item{...}{Additional arguments to pass to the `rgl::par3d` function.}
+\item{...}{Additional arguments to pass to the \code{\link[rgl:par3d]{rgl::par3d()}} function.}
 }
 \description{
-Displays the shaded map in 3D with the `rgl` package.
+Displays the shaded map in 3D with the \code{rgl} package.
 }
 \examples{
 #Plotting a spherical texture map of the built-in `montereybay` dataset.

--- a/man/plot_gg.Rd
+++ b/man/plot_gg.Rd
@@ -31,59 +31,59 @@ plot_gg(
 \arguments{
 \item{ggobj}{ggplot object to projected into 3D.}
 
-\item{width}{Default `3`. Width of ggplot, in `units`.}
+\item{width}{Default \code{3}. Width of ggplot, in \code{units}.}
 
-\item{height}{Default `3`. Height of ggplot, in `units`.}
+\item{height}{Default \code{3}. Height of ggplot, in \code{units}.}
 
-\item{height_aes}{Default `NULL`. Whether the `fill` or `color` aesthetic should be used for height values, 
-which the user can specify by passing either `fill` or `color` to this argument.
-Automatically detected. If both `fill` and `color` aesthetics are present, then `fill` is default.}
+\item{height_aes}{Default \code{NULL}. Whether the \code{fill} or \code{color} aesthetic should be used for height values,
+which the user can specify by passing either \code{fill} or \code{color} to this argument.
+Automatically detected. If both \code{fill} and \code{color} aesthetics are present, then \code{fill} is default.}
 
-\item{invert}{Default `FALSE`. If `TRUE`, the height mapping is inverted.}
+\item{invert}{Default \code{FALSE}. If \code{TRUE}, the height mapping is inverted.}
 
-\item{shadow_intensity}{Default `0.5`. The intensity of the calculated shadows.}
+\item{shadow_intensity}{Default \code{0.5}. The intensity of the calculated shadows.}
 
-\item{units}{Default `in`. One of c("in", "cm", "mm").}
+\item{units}{Default \verb{in}. One of c("in", "cm", "mm").}
 
-\item{scale}{Default `150`. Multiplier for vertical scaling: a higher number increases the height
+\item{scale}{Default \code{150}. Multiplier for vertical scaling: a higher number increases the height
 of the 3D transformation.}
 
-\item{pointcontract}{Default `0.7`. This multiplies the size of the points and shrinks
+\item{pointcontract}{Default \code{0.7}. This multiplies the size of the points and shrinks
 them around their center in the 3D surface mapping. Decrease this to reduce color bleed on edges, and set to
-`1` to turn off entirely. Note: If `size` is passed as an aesthetic to the same geom
-that is being mapped to elevation, this scaling will not be applied. If `alpha` varies on the variable 
-being mapped, you may want to set this to `1`, since the points now have a non-zero width stroke outline (however,
-mapping `alpha` in the same variable you are projecting to height is probably not a good choice. as the `alpha`
+\code{1} to turn off entirely. Note: If \code{size} is passed as an aesthetic to the same geom
+that is being mapped to elevation, this scaling will not be applied. If \code{alpha} varies on the variable
+being mapped, you may want to set this to \code{1}, since the points now have a non-zero width stroke outline (however,
+mapping \code{alpha} in the same variable you are projecting to height is probably not a good choice. as the \code{alpha}
 variable is ignored when performing the 3D projection).}
 
-\item{offset_edges}{Default `FALSE`. If `TRUE`, inserts a small amount of space between polygons for "geom_sf", "geom_tile", "geom_hex", and "geom_polygon" layers.
-If you pass in a number, the space between polygons will be a line of that width. Note: this feature may end up removing thin polygons 
+\item{offset_edges}{Default \code{FALSE}. If \code{TRUE}, inserts a small amount of space between polygons for "geom_sf", "geom_tile", "geom_hex", and "geom_polygon" layers.
+If you pass in a number, the space between polygons will be a line of that width. Note: this feature may end up removing thin polygons
 from the plot entirely--use with care.}
 
-\item{preview}{Default `FALSE`. If `TRUE`, the raytraced 2D ggplot will be displayed on the current device.}
+\item{preview}{Default \code{FALSE}. If \code{TRUE}, the raytraced 2D ggplot will be displayed on the current device.}
 
-\item{raytrace}{Default `FALSE`. Whether to add a raytraced layer.}
+\item{raytrace}{Default \code{FALSE}. Whether to add a raytraced layer.}
 
-\item{sunangle}{Default `315` (NW). If raytracing, the angle (in degrees) around the matrix from which the light originates.}
+\item{sunangle}{Default \code{315} (NW). If raytracing, the angle (in degrees) around the matrix from which the light originates.}
 
-\item{anglebreaks}{Default `seq(30,40,0.1)`. The azimuth angle(s), in degrees, as measured from the horizon from which the light originates.}
+\item{anglebreaks}{Default \code{seq(30,40,0.1)}. The azimuth angle(s), in degrees, as measured from the horizon from which the light originates.}
 
-\item{multicore}{Default `FALSE`. If raytracing and `TRUE`, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
-set `options("cores")` in which the multicore option will only use that many cores.}
+\item{multicore}{Default \code{FALSE}. If raytracing and \code{TRUE}, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
+set \code{options("cores")} in which the multicore option will only use that many cores.}
 
-\item{lambert}{Default `TRUE`. If raytracing, changes the intensity of the light at each point based proportional to the
+\item{lambert}{Default \code{TRUE}. If raytracing, changes the intensity of the light at each point based proportional to the
 dot product of the ray direction and the surface normal at that point. Zeros out all values directed away from
 the ray.}
 
-\item{reduce_size}{Default `NULL`. A number between 0 and 1 that specifies how much to reduce the resolution of the plot, for faster plotting.}
+\item{reduce_size}{Default \code{NULL}. A number between 0 and 1 that specifies how much to reduce the resolution of the plot, for faster plotting.}
 
-\item{save_height_matrix}{Default `FALSE`. If `TRUE`, the function will return the height matrix used for the ggplot.}
+\item{save_height_matrix}{Default \code{FALSE}. If \code{TRUE}, the function will return the height matrix used for the ggplot.}
 
-\item{save_shadow_matrix}{Default `FALSE`. If `TRUE`, the function will return the shadow matrix for use in future updates via the `shadow_cache` argument passed to `ray_shade`.}
+\item{save_shadow_matrix}{Default \code{FALSE}. If \code{TRUE}, the function will return the shadow matrix for use in future updates via the \code{shadow_cache} argument passed to \code{ray_shade}.}
 
-\item{saved_shadow_matrix}{Default `NULL`. A cached shadow matrix (saved by the a previous invocation of `plot_gg(..., save_shadow_matrix=TRUE)` to use instead of raytracing a shadow map each time.}
+\item{saved_shadow_matrix}{Default \code{NULL}. A cached shadow matrix (saved by the a previous invocation of \code{plot_gg(..., save_shadow_matrix=TRUE)} to use instead of raytracing a shadow map each time.}
 
-\item{...}{Additional arguments to be passed to `plot_3d()`.}
+\item{...}{Additional arguments to be passed to \code{\link[=plot_3d]{plot_3d()}}.}
 }
 \value{
 Opens a 3D plot in rgl.
@@ -94,11 +94,11 @@ Plots a ggplot2 object in 3D by mapping the color or fill aesthetic to elevation
 Currently, this function does not transform lines mapped to color into 3D.
 
 If there are multiple legends/guides due to multiple aesthetics being mapped (e.g. color and shape),
-the package author recommends that the user pass the order of the guides manually using the ggplot2 function "guides()`. 
+the package author recommends that the user pass the order of the guides manually using the ggplot2 function "guides()`.
 Otherwise, the order may change when processing the ggplot2 object and result in a mismatch between the 3D mapping
 and the underlying plot.
 
-Using the shape aesthetic with more than three groups is not recommended, unless the user passes in 
+Using the shape aesthetic with more than three groups is not recommended, unless the user passes in
 custom, solid shapes. By default in ggplot2, only the first three shapes are solid, which is a requirement to be projected
 into 3D.
 }

--- a/man/plot_map.Rd
+++ b/man/plot_map.Rd
@@ -9,12 +9,12 @@ plot_map(hillshade, rotate = 0, keep_user_par = FALSE, ...)
 \arguments{
 \item{hillshade}{Hillshade to be plotted.}
 
-\item{rotate}{Default `0`. Rotates the output. Possible values: `0`, `90`, `180`, `270`.}
+\item{rotate}{Default \code{0}. Rotates the output. Possible values: \code{0}, \code{90}, \code{180}, \code{270}.}
 
-\item{keep_user_par}{Default `TRUE`. Whether to keep the user's `par()` settings. Set to `FALSE` if you 
-want to set up a multi-pane plot (e.g. set `par(mfrow)`).}
+\item{keep_user_par}{Default \code{TRUE}. Whether to keep the user's \code{par()} settings. Set to \code{FALSE} if you
+want to set up a multi-pane plot (e.g. set \code{par(mfrow)}).}
 
-\item{...}{Additional arguments to pass to the `raster::plotRGB` function that displays the map.}
+\item{...}{Additional arguments to pass to the \code{\link[raster:plotRGB]{raster::plotRGB()}} function that displays the map.}
 }
 \description{
 Displays the map in the current device.

--- a/man/raster_to_matrix.Rd
+++ b/man/raster_to_matrix.Rd
@@ -9,7 +9,7 @@ raster_to_matrix(raster, verbose = interactive())
 \arguments{
 \item{raster}{The input raster. Either a RasterLayer object, or a filename.}
 
-\item{verbose}{Default `interactive()`. Will print dimensions of the resulting matrix.}
+\item{verbose}{Default \code{\link[=interactive]{interactive()}}. Will print dimensions of the resulting matrix.}
 }
 \description{
 Turns a raster into a matrix suitable for rayshader.

--- a/man/ray_shade.Rd
+++ b/man/ray_shade.Rd
@@ -22,37 +22,37 @@ ray_shade(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{sunaltitude}{Default `45`. The angle, in degrees (as measured from the horizon) from which the light originates. The width of the light
-is centered on this value and has an angular extent of 0.533 degrees, which is the angular extent of the sun. Use the `anglebreaks` argument
+\item{sunaltitude}{Default \code{45}. The angle, in degrees (as measured from the horizon) from which the light originates. The width of the light
+is centered on this value and has an angular extent of 0.533 degrees, which is the angular extent of the sun. Use the \code{anglebreaks} argument
 to create a softer (wider) light. This has a hard minimum/maximum of 0/90 degrees.}
 
-\item{sunangle}{Default `315` (NW). The angle, in degrees, around the matrix from which the light originates. Zero degrees is North, increasing clockwise.}
+\item{sunangle}{Default \code{315} (NW). The angle, in degrees, around the matrix from which the light originates. Zero degrees is North, increasing clockwise.}
 
-\item{maxsearch}{Defaults to the longest possible shadow given the `sunaltitude` and `heightmap`. 
+\item{maxsearch}{Defaults to the longest possible shadow given the \code{sunaltitude} and \code{heightmap}.
 Otherwise, this argument specifies the maximum distance that the system should propagate rays to check.}
 
-\item{lambert}{Default `TRUE`. Changes the intensity of the light at each point based proportional to the
+\item{lambert}{Default \code{TRUE}. Changes the intensity of the light at each point based proportional to the
 dot product of the ray direction and the surface normal at that point. Zeros out all values directed away from
 the ray.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation is in units
-of meters and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation is in units
+of meters and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{multicore}{Default `FALSE`. If `TRUE`, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
-set `options("cores")` in which the multicore option will only use that many cores.}
+\item{multicore}{Default \code{FALSE}. If \code{TRUE}, multiple cores will be used to compute the shadow matrix. By default, this uses all cores available, unless the user has
+set \code{options("cores")} in which the multicore option will only use that many cores.}
 
-\item{cache_mask}{Default `NULL`. A matrix of 1 and 0s, indicating which points on which the raytracer will operate.}
+\item{cache_mask}{Default \code{NULL}. A matrix of 1 and 0s, indicating which points on which the raytracer will operate.}
 
-\item{shadow_cache}{Default `NULL`. The shadow matrix to be updated at the points defined by the argument `cache_mask`.
-If present, this will only compute the raytraced shadows for those points with value `1` in the mask.}
+\item{shadow_cache}{Default \code{NULL}. The shadow matrix to be updated at the points defined by the argument \code{cache_mask}.
+If present, this will only compute the raytraced shadows for those points with value \code{1} in the mask.}
 
-\item{progbar}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, turns off progress bar.}
+\item{progbar}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, turns off progress bar.}
 
-\item{anglebreaks}{Default `NULL`. A vector of angle(s) in degrees (as measured from the horizon) specifying from where the light originates. 
-Use this instead of `sunaltitude` to create a softer shadow by specifying a wider light. E.g. `anglebreaks = seq(40,50,by=0.5)` creates a light 
+\item{anglebreaks}{Default \code{NULL}. A vector of angle(s) in degrees (as measured from the horizon) specifying from where the light originates.
+Use this instead of \code{sunaltitude} to create a softer shadow by specifying a wider light. E.g. \code{anglebreaks = seq(40,50,by=0.5)} creates a light
 10 degrees wide, as opposed to the default}
 
-\item{...}{Additional arguments to pass to the `makeCluster` function when `multicore=TRUE`.}
+\item{...}{Additional arguments to pass to the \code{\link[=makeCluster]{makeCluster()}} function when \code{multicore=TRUE}.}
 }
 \value{
 Matrix of light intensities at each point.

--- a/man/reduce_matrix_size.Rd
+++ b/man/reduce_matrix_size.Rd
@@ -9,12 +9,12 @@ reduce_matrix_size(heightmap, scale = 0.5, width = NULL, height = NULL)
 \arguments{
 \item{heightmap}{The elevation matrix.}
 
-\item{scale}{Default `0.5`. The amount to scale down the matrix. Scales down using bilinear interpolation.}
+\item{scale}{Default \code{0.5}. The amount to scale down the matrix. Scales down using bilinear interpolation.}
 
-\item{width}{Default `NULL`.  Alternative to `scale` argument. The desired output width. If `width` is less than 1, it will be interpreted as a scaling factor--
+\item{width}{Default \code{NULL}.  Alternative to \code{scale} argument. The desired output width. If \code{width} is less than 1, it will be interpreted as a scaling factor--
 e.g. 0.5 would halve the resolution for the width.}
 
-\item{height}{Default `NULL`. Alternative to `scale` argument. The desired output width. If `height` is less than 1, it will be interpreted as a scaling factor--
+\item{height}{Default \code{NULL}. Alternative to \code{scale} argument. The desired output width. If \code{height} is less than 1, it will be interpreted as a scaling factor--
 e.g. 0.5 would halve the resolution for the height.}
 }
 \description{

--- a/man/render_camera.Rd
+++ b/man/render_camera.Rd
@@ -9,14 +9,14 @@ render_camera(theta = NULL, phi = NULL, zoom = NULL, fov = NULL)
 \arguments{
 \item{theta}{Defaults to current value. Rotation angle.}
 
-\item{phi}{Defaults to current value. Azimuth angle. Maximum `90`.}
+\item{phi}{Defaults to current value. Azimuth angle. Maximum \code{90}.}
 
 \item{zoom}{Defaults to current value. Positive value indicating camera magnification.}
 
-\item{fov}{Defaults to current value. Field of view of the camera. Maximum `180`.}
+\item{fov}{Defaults to current value. Field of view of the camera. Maximum \code{180}.}
 }
 \description{
-Changes the position and properties of the camera around the scene. If no 
+Changes the position and properties of the camera around the scene. If no
 values are entered, prints and returns the current values.
 }
 \examples{

--- a/man/render_depth.Rd
+++ b/man/render_depth.Rd
@@ -36,82 +36,82 @@ render_depth(
 )
 }
 \arguments{
-\item{focus}{Defaults `0.5`. Depth in which to blur. Minimum 0, maximum 1.}
+\item{focus}{Defaults \code{0.5}. Depth in which to blur. Minimum 0, maximum 1.}
 
-\item{focallength}{Default `1`. Focal length of the virtual camera.}
+\item{focallength}{Default \code{1}. Focal length of the virtual camera.}
 
-\item{fstop}{Default `1`. F-stop of the virtual camera.}
+\item{fstop}{Default \code{1}. F-stop of the virtual camera.}
 
 \item{filename}{The filename of the image to be saved. If this is not given, the image will be plotted instead.}
 
-\item{preview_focus}{Default `FALSE`. If `TRUE`, a red line will be drawn across the image
+\item{preview_focus}{Default \code{FALSE}. If \code{TRUE}, a red line will be drawn across the image
 showing where the camera will be focused.}
 
-\item{bokehshape}{Default `circle`. Also built-in: `hex`. The shape of the bokeh.}
+\item{bokehshape}{Default \code{circle}. Also built-in: \code{hex}. The shape of the bokeh.}
 
-\item{bokehintensity}{Default `3`. Intensity of the bokeh when the pixel intensity is greater than `bokehlimit`.}
+\item{bokehintensity}{Default \code{3}. Intensity of the bokeh when the pixel intensity is greater than \code{bokehlimit}.}
 
-\item{bokehlimit}{Default `0.8`. Limit after which the bokeh intensity is increased by `bokehintensity`.}
+\item{bokehlimit}{Default \code{0.8}. Limit after which the bokeh intensity is increased by \code{bokehintensity}.}
 
-\item{rotation}{Default `0`. Number of degrees to rotate the hexagon bokeh shape.}
+\item{rotation}{Default \code{0}. Number of degrees to rotate the hexagon bokeh shape.}
 
-\item{gamma_correction}{Default `TRUE`. Controls gamma correction when adding colors. Default exponent of 2.2.}
+\item{gamma_correction}{Default \code{TRUE}. Controls gamma correction when adding colors. Default exponent of 2.2.}
 
-\item{aberration}{Default `0`. Adds chromatic aberration to the image. Maximum of `1`.}
+\item{aberration}{Default \code{0}. Adds chromatic aberration to the image. Maximum of \code{1}.}
 
-\item{transparent_water}{Default `FALSE`. If `TRUE`, depth is determined without water layer. User will have to re-render the water
-layer with `render_water()` if they want to recreate the water layer.}
+\item{transparent_water}{Default \code{FALSE}. If \code{TRUE}, depth is determined without water layer. User will have to re-render the water
+layer with \code{render_water()} if they want to recreate the water layer.}
 
-\item{heightmap}{Default `NULL`. The height matrix for the scene. Passing this will allow `render_depth()` 
-to automatically redraw the water layer if `transparent_water = TRUE`.}
+\item{heightmap}{Default \code{NULL}. The height matrix for the scene. Passing this will allow \code{\link[=render_depth]{render_depth()}}
+to automatically redraw the water layer if \code{transparent_water = TRUE}.}
 
-\item{zscale}{Default `NULL`. The zscale value for the heightmap. Passing this will allow `render_depth()` 
-to automatically redraw the water layer if `transparent_water = TRUE`.}
+\item{zscale}{Default \code{NULL}. The zscale value for the heightmap. Passing this will allow \code{\link[=render_depth]{render_depth()}}
+to automatically redraw the water layer if \code{transparent_water = TRUE}.}
 
-\item{title_text}{Default `NULL`. Text. Adds a title to the image, using magick::image_annotate.}
+\item{title_text}{Default \code{NULL}. Text. Adds a title to the image, using magick::image_annotate.}
 
-\item{title_offset}{Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
+\item{title_offset}{Default \code{c(20,20)}. Distance from the top-left (default, \code{gravity} direction in
 image_annotate) corner to offset the title.}
 
-\item{title_color}{Default `black`. Font color.}
+\item{title_color}{Default \code{black}. Font color.}
 
-\item{title_size}{Default `30`. Font size in pixels.}
+\item{title_size}{Default \code{30}. Font size in pixels.}
 
-\item{title_font}{Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
+\item{title_font}{Default \code{sans}. String with font family such as "sans", "mono", "serif", "Times", "Helvetica",
 "Trebuchet", "Georgia", "Palatino" or "Comic Sans".}
 
-\item{title_bar_color}{Default `NULL`. If a color, this will create a colored bar under the title.}
+\item{title_bar_color}{Default \code{NULL}. If a color, this will create a colored bar under the title.}
 
-\item{title_bar_alpha}{Default `0.5`. Transparency of the title bar.}
+\item{title_bar_alpha}{Default \code{0.5}. Transparency of the title bar.}
 
-\item{image_overlay}{Default `NULL`. Either a string indicating the location of a png image to overlay
-over the image (transparency included), or a 4-layer RGBA array. This image will be resized to the 
+\item{image_overlay}{Default \code{NULL}. Either a string indicating the location of a png image to overlay
+over the image (transparency included), or a 4-layer RGBA array. This image will be resized to the
 dimension of the image if it does not match exactly.}
 
-\item{vignette}{Default `FALSE`. If `TRUE` or numeric, a camera vignetting effect will be added to the image.
-`1` is the darkest vignetting, while `0` is no vignetting. If vignette is a length-2 vector, the second entry will
+\item{vignette}{Default \code{FALSE}. If \code{TRUE} or numeric, a camera vignetting effect will be added to the image.
+\code{1} is the darkest vignetting, while \code{0} is no vignetting. If vignette is a length-2 vector, the second entry will
 control the blurriness of the vignette effect.}
 
-\item{progbar}{Default `TRUE` if in an interactive session. Displays a progress bar.}
+\item{progbar}{Default \code{TRUE} if in an interactive session. Displays a progress bar.}
 
-\item{instant_capture}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, a slight delay is added 
+\item{instant_capture}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, a slight delay is added
 before taking the snapshot. This can help stop prevent rendering issues when running scripts.}
 
-\item{clear}{Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.}
+\item{clear}{Default \code{FALSE}. If \code{TRUE}, the current \code{rgl} device will be cleared.}
 
-\item{bring_to_front}{Default `FALSE`. Whether to bring the window to the front when rendering the snapshot.}
+\item{bring_to_front}{Default \code{FALSE}. Whether to bring the window to the front when rendering the snapshot.}
 
-\item{...}{Additional parameters to pass to magick::image_annotate.}
+\item{...}{Additional parameters to pass to \code{\link[magick:image_annotate]{magick::image_annotate()}}.}
 }
 \value{
 4-layer RGBA array.
 }
 \description{
-Adds depth of field to the current RGL scene by simulating a synthetic aperture. 
+Adds depth of field to the current RGL scene by simulating a synthetic aperture.
 
 The size of the circle of confusion is determined by the following formula (z_depth is from the image's depth map).
 
-\code{abs(z_depth-focus)*focal_length^2/(f_stop*z_depth*(focus - focal_length))}
+`abs(z_depth-focus)\emph{focal_length^2/(f_stop}z_depth*(focus - focal_length))``
 }
 \examples{
 \donttest{

--- a/man/render_highquality.Rd
+++ b/man/render_highquality.Rd
@@ -37,23 +37,23 @@ render_highquality(
 \arguments{
 \item{filename}{Filename of saved image. If missing, will display to current device.}
 
-\item{light}{Default `TRUE`. Whether there should be a light in the scene. If not, the scene will be lit with a bluish sky.}
+\item{light}{Default \code{TRUE}. Whether there should be a light in the scene. If not, the scene will be lit with a bluish sky.}
 
-\item{lightdirection}{Default `315`. Position of the light angle around the scene. 
-If this is a vector longer than one, multiple lights will be generated (using values from 
-`lightaltitude`, `lightintensity`, and `lightcolor`)}
+\item{lightdirection}{Default \code{315}. Position of the light angle around the scene.
+If this is a vector longer than one, multiple lights will be generated (using values from
+\code{lightaltitude}, \code{lightintensity}, and \code{lightcolor})}
 
-\item{lightaltitude}{Default `45`. Angle above the horizon that the light is located. 
-If this is a vector longer than one, multiple lights will be generated (using values from 
-`lightdirection`, `lightintensity`, and `lightcolor`)}
+\item{lightaltitude}{Default \code{45}. Angle above the horizon that the light is located.
+If this is a vector longer than one, multiple lights will be generated (using values from
+\code{lightdirection}, \code{lightintensity}, and \code{lightcolor})}
 
-\item{lightsize}{Default `NULL`. Radius of the light(s). Automatically chosen, but can be set here by the user.}
+\item{lightsize}{Default \code{NULL}. Radius of the light(s). Automatically chosen, but can be set here by the user.}
 
-\item{lightintensity}{Default `500`. Intensity of the light.}
+\item{lightintensity}{Default \code{500}. Intensity of the light.}
 
-\item{lightcolor}{Default `white`. The color of the light.}
+\item{lightcolor}{Default \code{white}. The color of the light.}
 
-\item{obj_material}{Default `rayrender::diffuse()`. The material properties of the object file.}
+\item{obj_material}{Default \code{\link[rayrender:diffuse]{rayrender::diffuse()}}. The material properties of the object file.}
 
 \item{cache_filename}{Name of temporary filename to store OBJ file, if the user does not want to rewrite the file each time.}
 
@@ -61,46 +61,46 @@ If this is a vector longer than one, multiple lights will be generated (using va
 
 \item{height}{Defaults to the height of the rgl window. Height of the rendering.}
 
-\item{title_text}{Default `NULL`. Text. Adds a title to the image, using magick::image_annotate.}
+\item{title_text}{Default \code{NULL}. Text. Adds a title to the image, using magick::image_annotate.}
 
-\item{title_offset}{Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-image_annotate) corner to offset the title.}
+\item{title_offset}{Default \code{c(20,20)}. Distance from the top-left (default, \code{gravity} direction in
+\code{\link[magick:image_annotate]{magick::image_annotate()}} corner to offset the title.}
 
-\item{title_color}{Default `black`. Font color.}
+\item{title_color}{Default \code{black}. Font color.}
 
-\item{title_size}{Default `30`. Font size in pixels.}
+\item{title_size}{Default \code{30}. Font size in pixels.}
 
-\item{title_font}{Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
+\item{title_font}{Default \code{sans}. String with font family such as "sans", "mono", "serif", "Times", "Helvetica",
 "Trebuchet", "Georgia", "Palatino" or "Comic Sans".}
 
-\item{title_bar_color}{Default `NULL`. If a color, this will create a colored bar under the title.}
+\item{title_bar_color}{Default \code{NULL}. If a color, this will create a colored bar under the title.}
 
-\item{title_bar_alpha}{Default `0.5`. Transparency of the title bar.}
+\item{title_bar_alpha}{Default \code{0.5}. Transparency of the title bar.}
 
-\item{ground_material}{Default `diffuse()`. Material defined by the rayrender material functions.}
+\item{ground_material}{Default \link[rayrender:diffuse]{diffuse()}. Material defined by the rayrender material functions.}
 
-\item{ground_size}{Default `100000`. The width of the plane representing the ground.}
+\item{ground_size}{Default \code{100000}. The width of the plane representing the ground.}
 
-\item{scene_elements}{Default `NULL`. Extra scene elements to add to the scene, created with rayrender.}
+\item{scene_elements}{Default \code{NULL}. Extra scene elements to add to the scene, created with rayrender.}
 
-\item{camera_location}{Default `NULL`. Custom position of the camera. The `FOV`, `width`, and `height` arguments will still
+\item{camera_location}{Default \code{NULL}. Custom position of the camera. The \code{FOV}, \code{width}, and \code{height} arguments will still
 be derived from the rgl window.}
 
-\item{camera_lookat}{Default `NULL`. Custom point at which the camera is directed. The `FOV`, `width`, and `height` arguments will still
+\item{camera_lookat}{Default \code{NULL}. Custom point at which the camera is directed. The \code{FOV}, \code{width}, and \code{height} arguments will still
 be derived from the rgl window.}
 
-\item{camera_interpolate}{Default `c(0,0)`. Maximum `1`, minimum `0`. Sets the camera at a point between the `rgl` view and the `camera_location` 
-and `camera_lookat` vectors.}
+\item{camera_interpolate}{Default \code{c(0,0)}. Maximum \code{1}, minimum \code{0}. Sets the camera at a point between the \code{rgl} view and the \code{camera_location}
+and \code{camera_lookat} vectors.}
 
-\item{clear}{Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.}
+\item{clear}{Default \code{FALSE}. If \code{TRUE}, the current \code{rgl} device will be cleared.}
 
-\item{print_scene_info}{Default `FALSE`. If `TRUE`, it will print the position and lookat point of the camera.}
+\item{print_scene_info}{Default \code{FALSE}. If \code{TRUE}, it will print the position and lookat point of the camera.}
 
-\item{...}{Additional parameters to pass to rayrender::render_scene()}
+\item{...}{Additional parameters to pass to \code{\link[rayrender:render_scene]{rayrender::render_scene()}}}
 }
 \description{
-Renders a raytraced version of the displayed rgl scene, using the `rayrender` package. 
-User can specify the light direction, intensity, and color, as well as specify the material of the 
+Renders a raytraced version of the displayed rgl scene, using the \code{rayrender} package.
+User can specify the light direction, intensity, and color, as well as specify the material of the
 ground and add additional scene elements.
 }
 \examples{

--- a/man/render_label.Rd
+++ b/man/render_label.Rd
@@ -34,46 +34,46 @@ render_label(
 
 \item{text}{The label text.}
 
-\item{x}{Either the `x` coordinate in the matrix.}
+\item{x}{Either the \code{x} coordinate in the matrix.}
 
-\item{y}{Either the `y` coordinate in the matrix.}
+\item{y}{Either the \code{y} coordinate in the matrix.}
 
 \item{z}{Elevation of the label, in units of the elevation matrix (scaled by zscale).}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units}
 
-\item{relativez}{Default `TRUE`. Whether `z` should be measured in relation to the underlying elevation at that point in the heightmap, or set absolutely (`FALSE`).}
+\item{relativez}{Default \code{TRUE}. Whether \code{z} should be measured in relation to the underlying elevation at that point in the heightmap, or set absolutely (\code{FALSE}).}
 
 \item{offset}{Elevation above the surface (at the label point) to start drawing the line.}
 
-\item{clear_previous}{Default `FALSE`. If `TRUE`, it will clear all existing text and lines rendered with `render_label()`. If no
-other arguments are passed to `render_label()`, this will just remove all existing lines.}
+\item{clear_previous}{Default \code{FALSE}. If \code{TRUE}, it will clear all existing text and lines rendered with \code{\link[=render_label]{render_label()}}. If no
+other arguments are passed to \code{render_label()}, this will just remove all existing lines.}
 
-\item{textsize}{Default `1`. A numeric character expansion value.}
+\item{textsize}{Default \code{1}. A numeric character expansion value.}
 
-\item{dashed}{Default `FALSE`. If `TRUE`, the label line is dashed.}
+\item{dashed}{Default \code{FALSE}. If \code{TRUE}, the label line is dashed.}
 
-\item{dashlength}{Default `auto`. Length, in units of the elevation matrix (scaled by `zscale`) of the dashes if `dashed = TRUE`.}
+\item{dashlength}{Default \code{auto}. Length, in units of the elevation matrix (scaled by \code{zscale}) of the dashes if \code{dashed = TRUE}.}
 
-\item{linewidth}{Default `3`. The line width.}
+\item{linewidth}{Default \code{3}. The line width.}
 
-\item{antialias}{Default `FALSE`. If `TRUE`, the line with be have anti-aliasing applied. NOTE: anti-aliasing can cause some unpredictable behavior with transparent surfaces.}
+\item{antialias}{Default \code{FALSE}. If \code{TRUE}, the line with be have anti-aliasing applied. NOTE: anti-aliasing can cause some unpredictable behavior with transparent surfaces.}
 
-\item{alpha}{Default `1`. Transparency of the label line.}
+\item{alpha}{Default \code{1}. Transparency of the label line.}
 
-\item{textalpha}{Default `1`. Transparency of the label text.}
+\item{textalpha}{Default \code{1}. Transparency of the label text.}
 
-\item{freetype}{Default `TRUE`. Set to `FALSE` if freetype is not installed (freetype enables anti-aliased fonts). NOTE: There are occasionally transparency issues when positioning Freetype fonts in front and behind a transparent surface.}
+\item{freetype}{Default \code{TRUE}. Set to \code{FALSE} if freetype is not installed (freetype enables anti-aliased fonts). NOTE: There are occasionally transparency issues when positioning Freetype fonts in front and behind a transparent surface.}
 
-\item{adjustvec}{Default `c(0.5,-0.5)`. The horizontal and vertical offset for the text. If `freetype = FALSE` and on macOS/Linux, this is adjusted to `c(0.33,-0.5)` to keep the type centered.}
+\item{adjustvec}{Default \code{c(0.5,-0.5)}. The horizontal and vertical offset for the text. If \code{freetype = FALSE} and on macOS/Linux, this is adjusted to \code{c(0.33,-0.5)} to keep the type centered.}
 
-\item{family}{Default `"sans"`. Font family. Choices are `c("serif", "sans", "mono", "symbol")`.}
+\item{family}{Default \code{"sans"}. Font family. Choices are \code{c("serif", "sans", "mono", "symbol")}.}
 
-\item{fonttype}{Default `"standard"`. The font type. Choices are `c("standard", "bold", "italic", "bolditalic")`. NOTE: These require FreeType fonts, which may not be installed on your system. See the documentation for rgl::text3d() for more information.}
+\item{fonttype}{Default \code{"standard"}. The font type. Choices are \code{c("standard", "bold", "italic", "bolditalic")}. NOTE: These require FreeType fonts, which may not be installed on your system. See the documentation for rgl::text3d() for more information.}
 
-\item{linecolor}{Default `black`. Color of the line.}
+\item{linecolor}{Default \code{black}. Color of the line.}
 
-\item{textcolor}{Default `black`. Color of the text.}
+\item{textcolor}{Default \code{black}. Color of the text.}
 }
 \description{
 Adds a marker and label to the current 3D plot

--- a/man/render_movie.Rd
+++ b/man/render_movie.Rd
@@ -28,59 +28,59 @@ render_movie(
 )
 }
 \arguments{
-\item{filename}{Filename. If not appended with `.mp4`, it will be appended automatically.}
+\item{filename}{Filename. If not appended with \code{.mp4}, it will be appended automatically.}
 
-\item{type}{Default `orbit`, which orbits the 3D object at the user-set camera settings `phi`, `zoom`, and `fov`. 
-Other options are `oscillate` (sine wave around `theta` value, covering 90 degrees), or `custom` (which uses the values from the 
-`theta`, `phi`, `zoom`, and `fov` vectors passed in by the user).}
+\item{type}{Default \code{orbit}, which orbits the 3D object at the user-set camera settings \code{phi}, \code{zoom}, and \code{fov}.
+Other options are \code{oscillate} (sine wave around \code{theta} value, covering 90 degrees), or \code{custom} (which uses the values from the
+\code{theta}, \code{phi}, \code{zoom}, and \code{fov} vectors passed in by the user).}
 
-\item{frames}{Default `360`. Number of frames to render.}
+\item{frames}{Default \code{360}. Number of frames to render.}
 
-\item{fps}{Default `30`. Frames per second. Recommmend either 30 or 60 for web.}
+\item{fps}{Default \code{30}. Frames per second. Recommmend either 30 or 60 for web.}
 
 \item{phi}{Defaults to current view. Azimuth values, in degrees.}
 
 \item{theta}{Default to current view. Theta values, in degrees.}
 
-\item{zoom}{Defaults to the current view. Zoom value, between `0` and `1`.}
+\item{zoom}{Defaults to the current view. Zoom value, between \code{0} and \code{1}.}
 
 \item{fov}{Defaults to the current view. Field of view values, in degrees.}
 
-\item{title_text}{Default `NULL`. Text. Adds a title to the movie, using magick::image_annotate.}
+\item{title_text}{Default \code{NULL}. Text. Adds a title to the movie, using magick::image_annotate.}
 
-\item{title_offset}{Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-image_annotate) corner to offset the title.}
+\item{title_offset}{Default \code{c(20,20)}. Distance from the top-left (default, \code{gravity} direction in
+\code{\link[magick:image_annotate]{magick::image_annotate()}}) corner to offset the title.}
 
-\item{title_color}{Default `black`. Font color.}
+\item{title_color}{Default \code{black}. Font color.}
 
-\item{title_size}{Default `30`. Font size in pixels.}
+\item{title_size}{Default \code{30}. Font size in pixels.}
 
-\item{title_font}{Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
+\item{title_font}{Default \code{sans}. String with font family such as "sans", "mono", "serif", "Times", "Helvetica",
 "Trebuchet", "Georgia", "Palatino" or "Comic Sans".}
 
-\item{title_bar_color}{Default `NULL`. If a color, this will create a colored bar under the title.}
+\item{title_bar_color}{Default \code{NULL}. If a color, this will create a colored bar under the title.}
 
-\item{title_bar_alpha}{Default `0.5`. Transparency of the title bar.}
+\item{title_bar_alpha}{Default \code{0.5}. Transparency of the title bar.}
 
-\item{image_overlay}{Default `NULL`. Either a string indicating the location of a png image to overlay
-over the whole movie (transparency included), or a 4-layer RGBA array. This image will be resized to the 
+\item{image_overlay}{Default \code{NULL}. Either a string indicating the location of a png image to overlay
+over the whole movie (transparency included), or a 4-layer RGBA array. This image will be resized to the
 dimension of the movie if it does not match exactly.}
 
-\item{vignette}{Default `FALSE`. If `TRUE` or numeric, a camera vignetting effect will be added to the image.
-`1` is the darkest vignetting, while `0` is no vignetting. If vignette is a length-2 vector, the second entry will
+\item{vignette}{Default \code{FALSE}. If \code{TRUE} or numeric, a camera vignetting effect will be added to the image.
+\code{1} is the darkest vignetting, while \code{0} is no vignetting. If vignette is a length-2 vector, the second entry will
 control the blurriness of the vignette effect.}
 
-\item{audio}{Default `NULL`. Optional file with audio to add to the video.}
+\item{audio}{Default \code{NULL}. Optional file with audio to add to the video.}
 
-\item{progbar}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, turns off progress bar. 
+\item{progbar}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, turns off progress bar.
 Will display a progress bar when adding an overlay or title.}
 
-\item{...}{Additional parameters to pass to magick::image_annotate.}
+\item{...}{Additional parameters to pass to \code{\link[magick:image_annotate]{magick::image_annotate()}}.}
 }
 \description{
-Renders a movie using the \pkg{av} package. Moves the camera around a 3D visualization 
+Renders a movie using the \pkg{av} package. Moves the camera around a 3D visualization
 using either a standard orbit, or accepts vectors listing user-defined values for each camera parameter. If the latter,
-the values must be equal in length to `frames` (or of length `1`, in which the value will be fixed).
+the values must be equal in length to \code{frames} (or of length \code{1}, in which the value will be fixed).
 }
 \examples{
 filename_movie = tempfile()

--- a/man/render_snapshot.Rd
+++ b/man/render_snapshot.Rd
@@ -24,38 +24,38 @@ render_snapshot(
 \arguments{
 \item{filename}{Filename of snapshot. If missing, will display to current device.}
 
-\item{clear}{Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.}
+\item{clear}{Default \code{FALSE}. If \code{TRUE}, the current \code{rgl} device will be cleared.}
 
-\item{title_text}{Default `NULL`. Text. Adds a title to the image, using magick::image_annotate.}
+\item{title_text}{Default \code{NULL}. Text. Adds a title to the image, using magick::image_annotate.}
 
-\item{title_offset}{Default `c(20,20)`. Distance from the top-left (default, `gravity` direction in 
-image_annotate) corner to offset the title.}
+\item{title_offset}{Default \code{c(20,20)}. Distance from the top-left (default, \code{gravity} direction in
+\code{\link[magick:image_annotate]{magick::image_annotate()}}) corner to offset the title.}
 
-\item{title_color}{Default `black`. Font color.}
+\item{title_color}{Default \code{black}. Font color.}
 
-\item{title_size}{Default `30`. Font size in pixels.}
+\item{title_size}{Default \code{30}. Font size in pixels.}
 
-\item{title_font}{Default `sans`. String with font family such as "sans", "mono", "serif", "Times", "Helvetica", 
+\item{title_font}{Default \code{sans}. String with font family such as "sans", "mono", "serif", "Times", "Helvetica",
 "Trebuchet", "Georgia", "Palatino" or "Comic Sans".}
 
-\item{title_bar_color}{Default `NULL`. If a color, this will create a colored bar under the title.}
+\item{title_bar_color}{Default \code{NULL}. If a color, this will create a colored bar under the title.}
 
-\item{title_bar_alpha}{Default `0.5`. Transparency of the title bar.}
+\item{title_bar_alpha}{Default \code{0.5}. Transparency of the title bar.}
 
-\item{image_overlay}{Default `NULL`. Either a string indicating the location of a png image to overlay
-over the image (transparency included), or a 4-layer RGBA array. This image will be resized to the 
+\item{image_overlay}{Default \code{NULL}. Either a string indicating the location of a png image to overlay
+over the image (transparency included), or a 4-layer RGBA array. This image will be resized to the
 dimension of the image if it does not match exactly.}
 
-\item{vignette}{Default `FALSE`. If `TRUE` or numeric, a camera vignetting effect will be added to the image.
-`1` is the darkest vignetting, while `0` is no vignetting. If vignette is a length-2 vector, the second entry will
+\item{vignette}{Default \code{FALSE}. If \code{TRUE} or numeric, a camera vignetting effect will be added to the image.
+\code{1} is the darkest vignetting, while \code{0} is no vignetting. If vignette is a length-2 vector, the second entry will
 control the blurriness of the vignette effect.}
 
-\item{instant_capture}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, a slight delay is added 
+\item{instant_capture}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, a slight delay is added
 before taking the snapshot. This can help stop prevent rendering issues when running scripts.}
 
-\item{bring_to_front}{Default `FALSE`. Whether to bring the window to the front when taking the snapshot.}
+\item{bring_to_front}{Default \code{FALSE}. Whether to bring the window to the front when taking the snapshot.}
 
-\item{...}{Additional parameters to pass to magick::image_annotate.}
+\item{...}{Additional parameters to pass to \code{\link[magick:image_annotate]{magick::image_annotate()}}.}
 }
 \value{
 Displays snapshot of current rgl plot (or saves to disk).

--- a/man/render_water.Rd
+++ b/man/render_water.Rd
@@ -19,22 +19,22 @@ render_water(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{waterdepth}{Default `0`.}
+\item{waterdepth}{Default \code{0}.}
 
-\item{watercolor}{Default `lightblue`.}
+\item{watercolor}{Default \code{lightblue}.}
 
-\item{zscale}{Default `1`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
-of 1 meter and the grid values are separated by 10 meters, `zscale` would be 10.}
+\item{zscale}{Default \code{1}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. For example, if the elevation levels are in units
+of 1 meter and the grid values are separated by 10 meters, \code{zscale} would be 10.}
 
-\item{wateralpha}{Default `0.5`. Water transparency.}
+\item{wateralpha}{Default \code{0.5}. Water transparency.}
 
-\item{waterlinecolor}{Default `NULL`. Color of the lines around the edges of the water layer.}
+\item{waterlinecolor}{Default \code{NULL}. Color of the lines around the edges of the water layer.}
 
-\item{waterlinealpha}{Default `1`. Water line tranparency.}
+\item{waterlinealpha}{Default \code{1}. Water line tranparency.}
 
-\item{linewidth}{Default `2`. Width of the edge lines in the scene.}
+\item{linewidth}{Default \code{2}. Width of the edge lines in the scene.}
 
-\item{remove_water}{Default `TRUE`. If `TRUE`, will remove existing water layer and replace it with new layer.}
+\item{remove_water}{Default \code{TRUE}. If \code{TRUE}, will remove existing water layer and replace it with new layer.}
 }
 \description{
 Adds water layer to the scene, removing the previous water layer if desired.

--- a/man/save_3dprint.Rd
+++ b/man/save_3dprint.Rd
@@ -14,20 +14,20 @@ save_3dprint(
 )
 }
 \arguments{
-\item{filename}{String with the filename. If `.stl` is not at the end of the string, it will be appended automatically.}
+\item{filename}{String with the filename. If \code{.stl} is not at the end of the string, it will be appended automatically.}
 
-\item{maxwidth}{Default `125`. Desired maximum width of the 3D print in millimeters. Uses the units set in `unit` argument. Can also pass in a string, "125mm" or "5in".}
+\item{maxwidth}{Default \code{125}. Desired maximum width of the 3D print in millimeters. Uses the units set in \code{unit} argument. Can also pass in a string, "125mm" or "5in".}
 
-\item{unit}{Default `mm`. Units of the `maxwidth` argument. Can also be set to inches with `in`.}
+\item{unit}{Default \code{mm}. Units of the \code{maxwidth} argument. Can also be set to inches with \verb{in}.}
 
-\item{rotate}{Default `TRUE`. If `FALSE`, the map will be printing on its side. This may improve resolution for some 3D printing types.}
+\item{rotate}{Default \code{TRUE}. If \code{FALSE}, the map will be printing on its side. This may improve resolution for some 3D printing types.}
 
-\item{remove_extras}{Default `TRUE`. Removes non-topographic features from base: lines, water, labels, and the shadow.}
+\item{remove_extras}{Default \code{TRUE}. Removes non-topographic features from base: lines, water, labels, and the shadow.}
 
-\item{clear}{Default `FALSE`. If `TRUE`, the current `rgl` device will be cleared.}
+\item{clear}{Default \code{FALSE}. If \code{TRUE}, the current \code{rgl} device will be cleared.}
 }
 \value{
-Writes an STL file to `filename`. Regardless of the unit displayed, the output STL is in millimeters.
+Writes an STL file to \code{filename}. Regardless of the unit displayed, the output STL is in millimeters.
 }
 \description{
 Writes a stereolithography (STL) file that can be used in 3D printing.

--- a/man/save_obj.Rd
+++ b/man/save_obj.Rd
@@ -7,11 +7,11 @@
 save_obj(filename, save_texture = TRUE, water_index_refraction = 1)
 }
 \arguments{
-\item{filename}{String with the filename. If `.obj` is not at the end of the string, it will be appended automatically.}
+\item{filename}{String with the filename. If \code{.obj} is not at the end of the string, it will be appended automatically.}
 
-\item{save_texture}{Default `TRUE`. If the texture should be saved along with the geometry.}
+\item{save_texture}{Default \code{TRUE}. If the texture should be saved along with the geometry.}
 
-\item{water_index_refraction}{Default `1`. The index of refraction for the rendered water.}
+\item{water_index_refraction}{Default \code{1}. The index of refraction for the rendered water.}
 }
 \description{
 Writes the textured 3D rayshader visualization to an OBJ file.

--- a/man/save_png.Rd
+++ b/man/save_png.Rd
@@ -9,11 +9,11 @@ save_png(hillshade, filename, rotate = 0, dpi = NULL)
 \arguments{
 \item{hillshade}{Array (or matrix) of hillshade to be written.}
 
-\item{filename}{String with the filename. If `.png` is not at the end of the string, it will be appended automatically.}
+\item{filename}{String with the filename. If \code{.png} is not at the end of the string, it will be appended automatically.}
 
 \item{rotate}{Default 0. Rotates the output. Possible values: 0, 90, 180, 270.}
 
-\item{dpi}{Default `NULL`. Optional DPI (dots per inch) specifying the resolution of the image.}
+\item{dpi}{Default \code{NULL}. Optional DPI (dots per inch) specifying the resolution of the image.}
 }
 \description{
 Writes the hillshaded map to file.

--- a/man/sphere_shade.Rd
+++ b/man/sphere_shade.Rd
@@ -17,19 +17,19 @@ sphere_shade(
 \arguments{
 \item{heightmap}{A two-dimensional matrix, where each entry in the matrix is the elevation at that point. All points are assumed to be evenly spaced.}
 
-\item{sunangle}{Default `315` (NW). The direction of the main highlight color (derived from the built-in palettes or the `create_texture` function).}
+\item{sunangle}{Default \code{315} (NW). The direction of the main highlight color (derived from the built-in palettes or the \code{create_texture} function).}
 
-\item{texture}{Default `imhof1`. Either a square matrix indicating the spherical texture mapping, or a string indicating one 
-of the built-in palettes (`imhof1`,`imhof2`,`imhof3`,`imhof4`,`desert`, `bw`, and `unicorn`).}
+\item{texture}{Default \code{imhof1}. Either a square matrix indicating the spherical texture mapping, or a string indicating one
+of the built-in palettes (\code{imhof1},\code{imhof2},\code{imhof3},\code{imhof4},\code{desert}, \code{bw}, and \code{unicorn}).}
 
-\item{normalvectors}{Default `NULL`. Cache of the normal vectors (from `calculate_normal` function). Supply this to speed up texture mapping.}
+\item{normalvectors}{Default \code{NULL}. Cache of the normal vectors (from \code{calculate_normal} function). Supply this to speed up texture mapping.}
 
-\item{colorintensity}{Default `1`. The intensity of the color mapping. Higher values will increase the intensity of the color mapping.}
+\item{colorintensity}{Default \code{1}. The intensity of the color mapping. Higher values will increase the intensity of the color mapping.}
 
-\item{zscale}{Default `1/colorintensity`. The ratio between the x and y spacing (which are assumed to be equal) and the z axis. 
-Ignored unless `colorintensity` missing.}
+\item{zscale}{Default \code{1/colorintensity}. The ratio between the x and y spacing (which are assumed to be equal) and the z axis.
+Ignored unless \code{colorintensity} missing.}
 
-\item{progbar}{Default `TRUE` if interactive, `FALSE` otherwise. If `FALSE`, turns off progress bar.}
+\item{progbar}{Default \code{TRUE} if interactive, \code{FALSE} otherwise. If \code{FALSE}, turns off progress bar.}
 }
 \value{
 RGB array of hillshaded texture mappings.


### PR DESCRIPTION
Hi,

I was impressed by your posts about rayshader/rayrender on twitter and when I visited the official docs website, I noticed that it displayed raw markdown formatting.

This PR enables roxygen markdown support.

I also manually fixed some entries, mainly missing links to functions (they were unformatted or simply formatted as code).

I could do the same for rayrender if you find this PR suitable.