### PR TITLE
Fixed typo where library 'isoband' was spelled 'isobands' in error message

### DIFF
--- a/R/generate_contour_overlay.R
+++ b/R/generate_contour_overlay.R
@@ -78,7 +78,7 @@ generate_contour_overlay = function(heightmap, levels=NA, nlevels=NA,
     stop("`sf` package required for generate_contour_overlay()")
   }
   if(!(length(find.package("isoband", quiet = TRUE)) > 0)) {
-    stop("`isobands` package required for generate_contour_overlay()")
+    stop("`isoband` package required for generate_contour_overlay()")
   }
   if(is.na(levels[1])) {
     if(is.na(nlevels[1])) {


### PR DESCRIPTION
Fixed typo in ```generate_contour_overlay.R``` where in error message for missing package ```isoband``` the package was spelled in the plural as `isobands' which does not exist. 