### PR TITLE
Use *3d functions in plot_3d

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports: doParallel,
          png,
          jpeg,
          magrittr,
-         rgl (>= 0.108.3),
+         rgl (>= 0.110.4),
          grDevices,
          grid,
          utils,
@@ -43,7 +43,7 @@ Suggests: reshape2,
           elevatr,
           gridExtra
 LinkingTo: Rcpp, progress, RcppArmadillo
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2.9000
 URL: https://www.rayshader.com, https://github.com/tylermorganwall/rayshader, https://www.rayshader.com/
 BugReports: https://github.com/tylermorganwall/rayshader/issues
 Remotes: tylermorganwall/rayimage,

--- a/R/plot_3d.R
+++ b/R/plot_3d.R
@@ -63,6 +63,8 @@
 #'to save a smaller 3D OBJ file to disk with `save_obj()`,
 #'@param verbose Default `TRUE`, if `interactive()`. Prints information about the mesh triangulation
 #'if `triangulate = TRUE`.
+#'@param add Default `FALSE`.  Whether to add to existing 
+#'plot, or open a new one.
 #'@param ... Additional arguments to pass to the `rgl::par3d` function.
 #'
 #'@import rgl
@@ -142,7 +144,7 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
                    soil_gradient = 2, soil_gradient_darken = 4,
                    theta=45, phi = 45, fov=0, zoom = 1, background="white", windowsize = 600,
                    precomputed_normals = NULL, asp = 1,
-                   triangulate = FALSE, max_error = 0, max_tri = 0, verbose = FALSE,
+                   triangulate = FALSE, max_error = 0, max_tri = 0, verbose = FALSE, add = FALSE,
                    ...) {
   #setting default zscale if montereybay is used and tell user about zscale
   argnameschar = unlist(lapply(as.list(sys.call()),as.character))[-1]
@@ -259,6 +261,10 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     triangulate = FALSE
   }
   
+  # Open a new window, or move to the next pane
+  if (!add || !cur3d())
+    next3d()
+  
   # We don't want rgl lighting
   save <- material3d(lit = FALSE)
   on.exit(material3d(save))
@@ -275,7 +281,7 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
                 y=heightmap/zscale,
                 normal_x = normalsz, normal_y = normalsy, normal_z = -normalsx,
                 texture = tempmap, tag = "surface",
-                col = "white", lit = FALSE)
+                col = "white")
   } else {
     tris = terrainmeshr::triangulate_matrix(heightmap, maxError = max_error, 
                                             maxTriangles = max_tri, start_index = 0, 
@@ -298,11 +304,12 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     tris[,1] = tris[,1] - nrow(heightmap)/2 +1
     tris[,3] = tris[,3] - ncol(heightmap)/2
     tris[,3] = -tris[,3]
-    rgl.triangles(tris, texcoords = texcoords, #normals = normal_comp,
-                  texture=tempmap,tag = "surface_tris")
+    triangles3d(tris, texcoords = texcoords, #normals = normal_comp,
+                  texture=tempmap,tag = "surface_tris",
+                col = "white")
   }
-  bg3d(color = background,texture=NULL)
-  rgl.viewpoint(zoom=zoom,phi=phi,theta=theta,fov=fov)
+  bg3d(color = background, texture=NULL)
+  view3d(zoom=zoom,phi=phi,theta=theta,fov=fov)
   par3d(windowRect = windowsize, mouseMode = c("none", "polar", "fov", "zoom", "pull"), ...)
   if(solid && !triangulate) {
     make_base(heightmap,basedepth=soliddepth,basecolor=solidcolor,zscale=zscale, 

--- a/R/plot_3d.R
+++ b/R/plot_3d.R
@@ -258,6 +258,11 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     }
     triangulate = FALSE
   }
+  
+  # We don't want rgl lighting
+  save <- material3d(lit = FALSE)
+  on.exit(material3d(save))
+  
   if(!triangulate) {
     if(!precomputed) {
       normals = calculate_normal(heightmap,zscale=zscale)
@@ -266,10 +271,11 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     normalsx = (t(normals$x[c(-1,-nrow(normals$x)),c(-1,-ncol(normals$x))]))
     normalsy = (t(normals$z[c(-1,-nrow(normals$z)),c(-1,-ncol(normals$z))]))
     normalsz = (t(normals$y[c(-1,-nrow(normals$y)),c(-1,-ncol(normals$y))]))
-    rgl.surface(x=1:nrow(heightmap)-nrow(heightmap)/2,z=(1:ncol(heightmap)-ncol(heightmap)/2),
+    surface3d(x=1:nrow(heightmap)-nrow(heightmap)/2,z=(1:ncol(heightmap)-ncol(heightmap)/2),
                 y=heightmap/zscale,
                 normal_x = normalsz, normal_y = normalsy, normal_z = -normalsx,
-                texture = tempmap, lit=FALSE,tag = "surface")
+                texture = tempmap, tag = "surface",
+                col = "white", lit = FALSE)
   } else {
     tris = terrainmeshr::triangulate_matrix(heightmap, maxError = max_error, 
                                             maxTriangles = max_tri, start_index = 0, 
@@ -293,7 +299,7 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     tris[,3] = tris[,3] - ncol(heightmap)/2
     tris[,3] = -tris[,3]
     rgl.triangles(tris, texcoords = texcoords, #normals = normal_comp,
-                  texture=tempmap,lit=FALSE,tag = "surface_tris")
+                  texture=tempmap,tag = "surface_tris")
   }
   bg3d(color = background,texture=NULL)
   rgl.viewpoint(zoom=zoom,phi=phi,theta=theta,fov=fov)
@@ -306,7 +312,6 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
     make_base_triangulated(tris,basedepth=soliddepth,basecolor=solidcolor)
   }
   if(!is.null(solidlinecolor) && solid) {
-    rgl::rgl.material(color=solidlinecolor, lit=FALSE)
     make_lines(heightmap,basedepth=soliddepth,linecolor=solidlinecolor,zscale=zscale,linewidth = linewidth)
   }
   if(shadow) {
@@ -317,11 +322,9 @@ plot_3d = function(hillshade, heightmap, zscale=1, baseshape="rectangle",
   }
   if(!is.null(waterlinecolor) && water) {
     if(all(!is.na(heightmap))) {
-      rgl::rgl.material(color=waterlinecolor,lit=FALSE)
       make_lines(fliplr(heightmap),basedepth=waterdepth,linecolor=waterlinecolor,
                  zscale=zscale,linewidth = linewidth,alpha=waterlinealpha,solid=FALSE)
     }
-    rgl::rgl.material(color=waterlinecolor,lit=FALSE)
     make_waterlines(heightmap,waterdepth=waterdepth,linecolor=waterlinecolor,
                     zscale=zscale,alpha=waterlinealpha,linewidth=linewidth,antialias=lineantialias)
   }

--- a/man/plot_3d.Rd
+++ b/man/plot_3d.Rd
@@ -45,6 +45,7 @@ plot_3d(
   max_error = 0,
   max_tri = 0,
   verbose = FALSE,
+  add = FALSE,
   ...
 )
 }
@@ -149,6 +150,9 @@ to save a smaller 3D OBJ file to disk with `save_obj()`,}
 
 \item{verbose}{Default `TRUE`, if `interactive()`. Prints information about the mesh triangulation
 if `triangulate = TRUE`.}
+
+\item{add}{Default `FALSE`.  Whether to add to existing 
+plot, or open a new one.}
 
 \item{...}{Additional arguments to pass to the `rgl::par3d` function.}
 }


### PR DESCRIPTION
This fixes issue #250 and other problems caused by using the old `rgl.*` interface in `rgl`.  That interface has been informally deprecated for several years now.

In order to allow the orientation `rayshader` uses (y is up), a change has been made to `rgl`, so the version requirement has been updated.  The version needed is currently on Github in https://github.com/dmurdoch/rgl.  If this PR is acceptable, I'd like to submit another one to handle other uses of `rgl.*` in other files before sending the `rgl` updates to CRAN, but once things settle down I will do so.