### PR TITLE
Use pak in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ function, and can be exported to an OBJ file.
 
 ``` r
 # To install the latest version from Github:
-# install.packages("devtools")
-devtools::install_github("tylermorganwall/rayshader")
+# install.packages("pak")
+pak::pkg_install("tylermorganwall/rayshader")
 ```
 
 On Ubuntu, the following libraries are required:


### PR DESCRIPTION
When I was installing with devtools I got the following warning:

```
Warning message:
`install_github()` was deprecated in devtools 2.5.0.
ℹ Please use pak::pak("user/repo") instead.
```

I have therefore updated the instructions to use [pak](https://pak.r-lib.org/) instead.